### PR TITLE
bugfix - hidden field threw a fatal error

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -104,6 +104,9 @@ class Bootstrap
                         case 'button':
                             return 'buttonTemplate';
 
+                        case 'hidden':
+                            return 'hiddenTemplate';
+
                         default:
                             return 'formGroupTemplate';
                     }
@@ -330,5 +333,19 @@ class Bootstrap
         }
 
         return $html;
+    }
+
+    /**
+     * Generates a hidden field
+     *
+     * <input type="hidden">
+     *
+     * @param Field $field
+     *
+     * @return string
+     */
+    public static function hiddenTemplate($field)
+    {
+        return $field->input->toHtml();
     }
 }


### PR DESCRIPTION
Hidden field directly in form:
$form = F::form([
'hidden' => F::hidden()->val('1'),
]);
Fatal error: Method FormManager\Fields\Hidden::__toString() must not throw an exception in ../vendor/form-manager/form-manager/src/Elements/ElementContainer.php on line 0

Hidden field in a form group:
$form = F::form([
'group' => F::group([
'hidden' => F::hidden()->val('1'),
])
]);
exception 'Exception' with message 'No labels allowed for this field' in .../vendor/form-manager/form-manager/src/Fields/Field.php:36

I don't know where this error comes from. Haven't had time for a deeper look at it. Simply fixed it with a "hiddenTemplate" method.